### PR TITLE
transaction log for native

### DIFF
--- a/api/accounting.js
+++ b/api/accounting.js
@@ -436,13 +436,13 @@ accounting.get("/native-transaction-log", async function (req, res, next) {
         const start = parseInt(query.start);
         const end = parseInt(query.end);
 
-        const [incoming, outgoing] = await gatherNativeTransactionData(
+        const [incoming, outgoing, outgoingXcm] = await gatherNativeTransactionData(
           start,
           end,
           account,
         );
 
-        const txnLog = generateNativeTxnLog(incoming, outgoing);
+        const txnLog = generateNativeTxnLog(incoming, outgoing, outgoingXcm);
 
         res.send(JSON.stringify(txnLog));
     } catch (e) {

--- a/api/accounting.js
+++ b/api/accounting.js
@@ -442,7 +442,7 @@ accounting.get("/native-transaction-log", async function (req, res, next) {
           account,
         );
 
-        const txnLog = generateNativeTxnLog(incoming, outgoing, issues);
+        const txnLog = generateNativeTxnLog(incoming, outgoing);
 
         res.send(JSON.stringify(txnLog));
     } catch (e) {

--- a/api/accounting.js
+++ b/api/accounting.js
@@ -436,13 +436,13 @@ accounting.get("/native-transaction-log", async function (req, res, next) {
         const start = parseInt(query.start);
         const end = parseInt(query.end);
 
-        const [incoming, incomingDrips, outgoing, outgoingXcm] = await gatherNativeTransactionData(
+        const [incoming, incomingDrips, incomingXcm, outgoing, outgoingXcm] = await gatherNativeTransactionData(
           start,
           end,
           account,
         );
 
-        const txnLog = generateNativeTxnLog(incoming, incomingDrips, outgoing, outgoingXcm);
+        const txnLog = generateNativeTxnLog(incoming, incomingDrips, incomingXcm, outgoing, outgoingXcm);
 
         res.send(JSON.stringify(txnLog));
     } catch (e) {

--- a/api/accounting.js
+++ b/api/accounting.js
@@ -436,13 +436,13 @@ accounting.get("/native-transaction-log", async function (req, res, next) {
         const start = parseInt(query.start);
         const end = parseInt(query.end);
 
-        const [incoming, outgoing, outgoingXcm] = await gatherNativeTransactionData(
+        const [incoming, incomingDrips, outgoing, outgoingXcm] = await gatherNativeTransactionData(
           start,
           end,
           account,
         );
 
-        const txnLog = generateNativeTxnLog(incoming, outgoing, outgoingXcm);
+        const txnLog = generateNativeTxnLog(incoming, incomingDrips, outgoing, outgoingXcm);
 
         res.send(JSON.stringify(txnLog));
     } catch (e) {

--- a/data.js
+++ b/data.js
@@ -81,7 +81,7 @@ export async function gatherAccountingOverview(
                 i
             );
             data.push(accountingData);
-            db.insertIntoAccountDataCache(
+            await db.insertIntoAccountDataCache(
                 account,
                 year,
                 i,
@@ -348,8 +348,7 @@ export async function gatherRewardsData(api, cid) {
             ([key]) => parseInt(key) < currentCindex - 1
         )
     );
-    db.insertIntoRewardsDataCache(cid, dataToBeCached);
-
+    await db.insertIntoRewardsDataCache(cid, dataToBeCached);
     return result;
 }
 
@@ -551,13 +550,15 @@ export async function getMoneyVelocity(
                 cid
             );
         } else {
-            accountingData = await getAccountingData(
-                api,
-                account,
-                cid,
-                year,
-                i
-            );
+            console.error("not implemented yet for current month");
+            accountingData = []
+            // accountingData = await getAccountingData(
+            //     api,
+            //     account,
+            //     cid,
+            //     year,
+            //     i
+            // );
         }
 
         totalTurnoverOrVolume = accountingData.reduce(
@@ -585,7 +586,7 @@ export async function getMoneyVelocity(
 
     const moneyVelocity = (totalTurnoverOrVolume * 12) / averagetotalIssuance;
     if (canBeCached(month, year)) {
-        db.insertIntoGeneralCache(
+        await db.insertIntoGeneralCache(
             "moneyVelocity",
             { cid, year, month },
             { moneyVelocity }
@@ -607,7 +608,7 @@ export async function getVolume(cid, year, month) {
     const transactionVolume = await getTransactionVolume(cid, start, end);
 
     if (canBeCached(month, year)) {
-        db.insertIntoGeneralCache(
+        await db.insertIntoGeneralCache(
             "transactionVolume",
             { cid, year, month },
             { transactionVolume }
@@ -777,7 +778,7 @@ export async function getTransactionActivityLog(
             );
             data.push(transactionActivityData);
 
-            db.insertIntoGeneralCache(
+            await db.insertIntoGeneralCache(
                 "transactionActivity",
                 { cid, year, month: i },
                 transactionActivityData

--- a/data.js
+++ b/data.js
@@ -376,6 +376,24 @@ export function generateTxnLog(incoming, outgoing, issues) {
     return txnLog;
 }
 
+export function generateNativeTxnLog(incoming, outgoing) {
+    const incomingLog = incoming.map((e) => ({
+        blockNumber: e.blockNumber.toString(),
+        timestamp: e.timestamp.toString(),
+        counterParty: e.signer.Id,
+        amount: e.args.value,
+    }));
+    const outgoingLog = outgoing.map((e) => ({
+        blockNumber: e.blockNumber.toString(),
+        timestamp: e.timestamp.toString(),
+        counterParty: e.args.dest.Id,
+        amount: -e.args.value,
+    }));
+    const txnLog = incomingLog.concat(outgoingLog);
+    txnLog.sort((a, b) => parseInt(a.timestamp) - parseInt(b.timestamp));
+    return txnLog;
+}
+
 function groupTransactionsByDay(txnLog) {
     return txnLog.reduce((acc, cur) => {
         const d = new Date(parseInt(cur.timestamp));

--- a/data.js
+++ b/data.js
@@ -377,7 +377,7 @@ export function generateTxnLog(incoming, outgoing, issues) {
     return txnLog;
 }
 
-export function generateNativeTxnLog(incoming, incomingDrips, outgoing, outgoingXcm) {
+export function generateNativeTxnLog(incoming, incomingDrips, incomingXcm, outgoing, outgoingXcm) {
     const incomingLog = incoming.map((e) => ({
         blockNumber: e.blockNumber.toString(),
         timestamp: e.timestamp.toString(),
@@ -390,6 +390,14 @@ export function generateNativeTxnLog(incoming, incomingDrips, outgoing, outgoing
             timestamp: e.timestamp.toString(),
             counterParty: e.data[0],
             amount: toNativeDecimal(e.data[2]),
+        }
+    });
+    const incomingXcmLog = incomingXcm.map((e) => {
+        return {
+            blockNumber: e.blockNumber.toString(),
+            timestamp: e.timestamp.toString(),
+            counterParty: "XCMteleporter",
+            amount: toNativeDecimal(e.data.amount),
         }
     });
     const outgoingLog = outgoing.map((e) => ({
@@ -439,7 +447,11 @@ export function generateNativeTxnLog(incoming, incomingDrips, outgoing, outgoing
         };
     });
 
-    const txnLog = incomingLog.concat(incomingDripsLog).concat(outgoingLog).concat(outgoingXcmLog);
+    const txnLog = incomingLog
+      .concat(incomingDripsLog)
+      .concat(incomingXcmLog)
+      .concat(outgoingLog)
+      .concat(outgoingXcmLog);
     txnLog.sort((a, b) => parseInt(a.timestamp) - parseInt(b.timestamp));
     return txnLog;
 }

--- a/db.js
+++ b/db.js
@@ -26,13 +26,18 @@ class Database {
     }
 
     async insertIntoGeneralCache(cacheIdentifier, query, data) {
-        await this.generalCache.replaceOne(
-            { ...query, cacheIdentifier },
-            { ...query, cacheIdentifier, data },
-            {
-                upsert: true,
-            }
-        );
+        try {
+            console.debug('inserting into general cache', cacheIdentifier, query)
+            await this.generalCache.replaceOne(
+              { ...query, cacheIdentifier },
+              { ...query, cacheIdentifier, data },
+              {
+                  upsert: true,
+              }
+            );
+        } catch (e) {
+            console.error(e);
+        }
     }
     async getFromGeneralCache(cacheIdentifier, query) {
         return (
@@ -43,13 +48,18 @@ class Database {
     }
 
     async insertIntoAccountDataCache(account, year, month, cid, data) {
-        await this.accountData.replaceOne(
-            { account, year, month, cid },
-            { account, year, month, cid, data },
-            {
-                upsert: true,
-            }
-        );
+        try {
+            console.debug('inserting into account data cache', account, year, month, cid)
+            await this.accountData.replaceOne(
+              {account, year, month, cid},
+              {account, year, month, cid, data},
+              {
+                  upsert: true,
+              }
+            );
+        } catch (e) {
+            console.error(e);
+        }
     }
     async getFromAccountDataCache(account, year, cid) {
         return (
@@ -66,13 +76,18 @@ class Database {
     }
 
     async insertIntoRewardsDataCache(cid, data) {
-        await this.rewardsData.replaceOne(
+        try {
+            console.debug('inserting into rewards data cache', cid)
+            await this.rewardsData.replaceOne(
             { cid },
             { cid, data },
             {
                 upsert: true,
             }
         );
+        } catch (e) {
+            console.error(e);
+        }
     }
 
     async getFromRewardsDataCache(cid) {

--- a/graphQl.js
+++ b/graphQl.js
@@ -78,6 +78,18 @@ export async function getNativeTransfers(start, end, address, cid, direction) {
     return await cursor.toArray();
 }
 
+export async function getNativeFaucetDrips(start, end, address) {
+    let query = {
+        section: "encointerFaucet",
+        method: "Dripped",
+        "data.1": address,
+        timestamp: { $gte: start, $lte: end }
+    };
+    const cursor = await db.indexer
+      .collection("events")
+      .find(query, { sort: { timestamp: 1 } });
+    return await cursor.toArray();
+}
 export async function getNativeXcmOutwards(start, end, address) {
     let query = {
         section: "polkadotXcm",
@@ -177,6 +189,7 @@ export async function gatherTransactionData(start, end, address, cid) {
 
 export async function gatherNativeTransactionData(start, end, address) {
     const incoming = await getNativeTransfers(start, end, address, INCOMING);
+    const incomingDrips = await getNativeFaucetDrips(start, end, address);
     const outgoing = await getNativeTransfers(start, end, address, OUTGOING);
     const outgoingXcm = await getNativeXcmOutwards(start, end, address);
 
@@ -186,6 +199,7 @@ export async function gatherNativeTransactionData(start, end, address) {
     const numDistinctClients = new Set(incoming.map((e) => e.signer.Id)).size;
     return [
         incoming,
+        incomingDrips,
         outgoing,
         outgoingXcm,
         sumIncoming,

--- a/graphQl.js
+++ b/graphQl.js
@@ -160,8 +160,8 @@ export async function gatherTransactionData(start, end, address, cid) {
 }
 
 export async function gatherNativeTransactionData(start, end, address) {
-    let incoming = await getNativeTransfers(start, end, address, cid, INCOMING);
-    const outgoing = await getNativeTransfers(start, end, address, cid, OUTGOING);
+    let incoming = await getNativeTransfers(start, end, address, INCOMING);
+    const outgoing = await getNativeTransfers(start, end, address, OUTGOING);
 
     const sumIncoming = incoming.reduce((acc, cur) => acc + cur.args.value, 0);
     const sumOutgoing = outgoing.reduce((acc, cur) => acc + cur.args.value, 0);

--- a/graphQl.js
+++ b/graphQl.js
@@ -57,7 +57,7 @@ export async function getTransfers(start, end, address, cid, direction) {
     return await cursor.toArray();
 }
 
-export async function getNativeTransfers(start, end, address, cid, direction) {
+export async function getNativeTransfers(start, end, address, direction) {
     let query = {
         section: "balances",
         $or: [

--- a/graphQl.js
+++ b/graphQl.js
@@ -106,6 +106,18 @@ export async function getNativeXcmOutwards(start, end, address) {
     return await cursor.toArray();
 }
 
+export async function getNativeXcmTeleportsIncoming(start, end, address) {
+    let query = {
+        section: "balances",
+        method: "Minted",
+        timestamp: { $gte: start, $lte: end },
+    };
+    query["data.who"] = address;
+    const cursor = await db.indexer
+      .collection("events")
+      .find(query, { sort: { timestamp: 1 } });
+    return await cursor.toArray();
+}
 async function getIssues(start, end, address, cid) {
     const cursor = await db.indexer.collection("events").find(
         {
@@ -190,6 +202,7 @@ export async function gatherTransactionData(start, end, address, cid) {
 export async function gatherNativeTransactionData(start, end, address) {
     const incoming = await getNativeTransfers(start, end, address, INCOMING);
     const incomingDrips = await getNativeFaucetDrips(start, end, address);
+    const incomingXcm = await getNativeXcmTeleportsIncoming(start, end, address);
     const outgoing = await getNativeTransfers(start, end, address, OUTGOING);
     const outgoingXcm = await getNativeXcmOutwards(start, end, address);
 
@@ -200,6 +213,7 @@ export async function gatherNativeTransactionData(start, end, address) {
     return [
         incoming,
         incomingDrips,
+        incomingXcm,
         outgoing,
         outgoingXcm,
         sumIncoming,

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ async function main() {
     const app = express();
     app.set("api", api);
     app.use(function (req, res, next) {
-        console.log("Received new request:", req.url);
+        console.log("Received new request:", req.url, "from:", req.headers.origin);
         var send = res.send;
         res.send = function (body) {
             console.log(

--- a/util.js
+++ b/util.js
@@ -1,4 +1,5 @@
 import base58 from "bs58";
+import BN from "bn.js";
 
 export function getMonthName(idx) {
     const monthNames = [
@@ -63,4 +64,16 @@ export function reduceObjects(objectsList) {
       });
       return result;
     }, {});
+  }
+
+  export function toNativeDecimal(value) {
+    const cleanedValue = value.toString().replace(/,/g, '');
+    const bnValue = new BN(cleanedValue, 10);
+    const divisor = new BN('1000000000000', 10);
+    const { div: quotient, mod: remainder } = bnValue.divmod(divisor);
+    // Convert quotient and remainder to strings
+    const quotientStr = quotient.toString(10);
+    const remainderStr = remainder.toString(10).padStart(12, '0');
+    // Combine quotient and remainder to form a decimal number
+    return parseFloat(`${quotientStr}.${remainderStr}`);
   }


### PR DESCRIPTION
similar to CC tx log we use for the app, this introduces a native (KSM) tx log query

It considers
* `balances.transfer*`
* `encointerFaucet.Dripped`
* outgoing `polkadotXcm.limitedTeleportAsset` and `reserveTransferAsset` (this may need to be extended)
* incoming XCM teleport using `balances.Minted` events

* [x] depends on an update to litescan : https://github.com/brenzi/litescan/commit/3b359478c0a834083d31d29f7aa57e2041bee4d8

## testing

```
curl "127.0.0.1:8081/v1/accounting/native-transaction-log?start=1470000000000&end=1776250900000&account=DGeoBv3E9xniabhyWsSjd25Te8ZmjQ7zndc2VVbmU8zmZQB"

# should yield all types of tx:
# GDcRrT5id2uFsYaE8NgfpnUkNKJpBWU4C2f5EFZQZiVZb9c is the faucet PioneerPot
[{"blockNumber":"1057660","timestamp":"1660379100301","counterParty":"GCFEM2oEpqD8EXnZNiva9cmfK6UWgWqFycxwn88s1gkuqvF","amount":0.1},
{"blockNumber":"3896478","timestamp":"1696321914507","counterParty":"GDcRrT5id2uFsYaE8NgfpnUkNKJpBWU4C2f5EFZQZiVZb9c","amount":0.1},
{"blockNumber":"4207716","timestamp":"1700114262423","counterParty":"GDcRrT5id2uFsYaE8NgfpnUkNKJpBWU4C2f5EFZQZiVZb9c","amount":0.1},
{"blockNumber":"4374824","timestamp":"1702144188511","counterParty":"GDcRrT5id2uFsYaE8NgfpnUkNKJpBWU4C2f5EFZQZiVZb9c","amount":0.1},
{"blockNumber":"4873799","timestamp":"1708466202384","counterParty":"GDcRrT5id2uFsYaE8NgfpnUkNKJpBWU4C2f5EFZQZiVZb9c","amount":0.1},
{"blockNumber":"4873801","timestamp":"1708466226317","counterParty":"GDcRrT5id2uFsYaE8NgfpnUkNKJpBWU4C2f5EFZQZiVZb9c","amount":0.1},
{"blockNumber":"4910615","timestamp":"1708938882000","counterParty":"GDcRrT5id2uFsYaE8NgfpnUkNKJpBWU4C2f5EFZQZiVZb9c","amount":0.1},
{"blockNumber":"5246759","timestamp":"1713192660000","counterParty":"Relay","amount":-0.1},
{"blockNumber":"5489337","timestamp":"1716193464000","counterParty":"GDcRrT5id2uFsYaE8NgfpnUkNKJpBWU4C2f5EFZQZiVZb9c","amount":0.1},
{"blockNumber":"5489500","timestamp":"1716195468000","counterParty":"Relay","amount":-0.711029511965},
{"blockNumber":"6213829","timestamp":"1725777474000","counterParty":"GDcRrT5id2uFsYaE8NgfpnUkNKJpBWU4C2f5EFZQZiVZb9c","amount":0.1},
{"blockNumber":"6353540","timestamp":"1727540478000","counterParty":"EyXct79ZDWdQfcSgJTG5texKM9wJj3quyh1ugPDVSkSt3Xm","amount":0.077},
{"blockNumber":"6353610","timestamp":"1727541354000","counterParty":"EyXct79ZDWdQfcSgJTG5texKM9wJj3quyh1ugPDVSkSt3Xm","amount":-0.076}]
```
incoming teleport:
```
curl "127.0.0.1:8081/v1/accounting/native-transaction-log?start=1470000000000&end=1876250900000&account=EyXct79ZDWdQfcSgJTG5texKM9wJj3quyh1ugPDVSkSt3Xm"

# should yield
....
{"blockNumber":"6354189","timestamp":"1727548590000","counterParty":"XCMteleporter","amount":0.99984434441}

```