### PR TITLE
Add faucet drips API endpoint

### DIFF
--- a/api/faucet.js
+++ b/api/faucet.js
@@ -1,0 +1,114 @@
+import express from "express";
+import db from "../db.js";
+
+const faucet = express.Router();
+
+/**
+ * @swagger
+ * /v1/faucet/drips:
+ *   get:
+ *     description: Retrieve faucet drip statistics per community per month
+ *     tags:
+ *       - faucet
+ *     responses:
+ *          '200':
+ *              description: Success
+ *          '403':
+ *              description: Permission denied
+ *     security:
+ *      - cookieAuth: []
+ */
+faucet.get("/drips", async function (req, res, next) {
+    try {
+        if (!req.session.isReadonlyAdmin) {
+            res.sendStatus(403);
+            return;
+        }
+
+        const communities = await db.getAllCommunities();
+        const cidToName = {};
+        communities.forEach((c) => (cidToName[c.cid] = c.name));
+
+        const matchStage = {
+            $match: {
+                section: "encointerFaucet",
+                method: "drip",
+                success: true,
+            },
+        };
+
+        const [monthlyResults, uniqueResults] = await Promise.all([
+            db.extrinsics
+                .aggregate([
+                    matchStage,
+                    {
+                        $group: {
+                            _id: {
+                                cid: "$args.cid",
+                                month: {
+                                    $dateToString: {
+                                        format: "%Y-%m",
+                                        date: { $toDate: "$timestamp" },
+                                    },
+                                },
+                            },
+                            count: { $sum: 1 },
+                        },
+                    },
+                    { $sort: { "_id.month": 1 } },
+                ])
+                .toArray(),
+            db.extrinsics
+                .aggregate([
+                    matchStage,
+                    {
+                        $group: {
+                            _id: {
+                                cid: "$args.cid",
+                                signer: "$signer.Id",
+                            },
+                        },
+                    },
+                    {
+                        $group: {
+                            _id: "$_id.cid",
+                            count: { $sum: 1 },
+                        },
+                    },
+                ])
+                .toArray(),
+        ]);
+
+        const monthlyDrips = {};
+        for (const r of monthlyResults) {
+            const name = cidToName[r._id.cid] || r._id.cid;
+            const month = r._id.month;
+            if (!monthlyDrips[month]) monthlyDrips[month] = {};
+            monthlyDrips[month][name] = r.count;
+        }
+
+        const uniqueDrippers = {};
+        for (const r of uniqueResults) {
+            const name = cidToName[r._id] || r._id;
+            uniqueDrippers[name] = r.count;
+        }
+
+        const communityNames = [
+            ...new Set(
+                monthlyResults.map((r) => cidToName[r._id.cid] || r._id.cid)
+            ),
+        ];
+
+        res.send(
+            JSON.stringify({
+                monthlyDrips,
+                uniqueDrippers,
+                communities: communityNames,
+            })
+        );
+    } catch (e) {
+        next(e);
+    }
+});
+
+export default faucet;

--- a/api/v1.js
+++ b/api/v1.js
@@ -3,6 +3,7 @@ import express from "express";
 import accounting from "./accounting.js";
 import auth from "./auth.js";
 import communities from "./communities.js";
+import faucet from "./faucet.js";
 import indexer2 from "./indexer2.js";
 
 
@@ -12,6 +13,7 @@ v1.use("/accounting", accounting);
 
 v1.use("/auth", auth);
 v1.use("/communities", communities);
+v1.use("/faucet", faucet);
 v1.use("/indexer2", indexer2);
 
 export default v1;

--- a/scripts/warm-caches.js
+++ b/scripts/warm-caches.js
@@ -180,6 +180,12 @@ async function main() {
         }
     }
 
+    // ── faucet ──────────────────────────────────────────────────────────
+    if (authed) {
+        console.log("\n[faucet]");
+        await hit("faucet-drips", "/v1/faucet/drips");
+    }
+
     // ── account-specific endpoints (sample account, Leu) ──────────────
     console.log("\n[account-specific / sample]");
     await hit(


### PR DESCRIPTION
## Summary
- New `GET /v1/faucet/drips` endpoint returning monthly drip counts and unique dripper counts per community
- Aggregates successful `encointerFaucet.drip` extrinsics by `args.cid` (monthly) and `signer.Id` (unique drippers)
- Auth-gated by `isReadonlyAdmin`, consistent with other reporting endpoints

## Test plan
- [ ] Verify endpoint returns expected JSON shape: `{monthlyDrips, uniqueDrippers, communities}`
- [ ] Verify 403 for unauthenticated requests
- [ ] Verify community names resolve correctly from cid

🤖 Generated with [Claude Code](https://claude.com/claude-code)