### PR TITLE
Add GHA CI workflow and cache warming script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Start server
+        env:
+          DB_URL: ${{ secrets.MONGODB_URL }}
+          SECRET_KEY: ci-test-secret
+          # Use default ENCOINTER_RPC (wss://kusama.api.encointer.org)
+        run: node index.js &
+
+      - name: Wait for server
+        run: |
+          for i in $(seq 1 120); do
+            if curl -sf http://localhost:8081/v1/communities/all-communities > /dev/null 2>&1; then
+              echo "Server ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Server failed to start within 120s"
+          exit 1
+
+      - name: Smoke tests
+        run: node scripts/warm-caches.js --quick

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "node index.js",
+    "test": "node scripts/warm-caches.js --quick",
+    "warm-caches": "node scripts/warm-caches.js"
   },
   "author": "pifragile",
   "license": "ISC",

--- a/scripts/warm-caches.js
+++ b/scripts/warm-caches.js
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+// Cache warming / smoke test script.
+//
+// Usage:
+//   Production (all endpoints, all years):
+//     BASE_URL=https://accounting.encointer.org node scripts/warm-caches.js
+//
+//   CI (DB-only endpoints, current year):
+//     node scripts/warm-caches.js --quick
+//
+// Exits 0 if all attempted endpoints succeed, 1 otherwise.
+
+const BASE_URL = process.env.BASE_URL || "http://localhost:8081";
+const QUICK = process.argv.includes("--quick");
+
+const SAMPLE_ACCOUNT = "DGeoBv3E9xniabhyWsSjd25Te8ZmjQ7zndc2VVbmU8zmZQB";
+const TREASURY_CIDS = new Set(["u0qj944rhWE", "kygch5kVGq7", "s1vrqQL2SD"]);
+const START_YEAR = 2022;
+
+let passed = 0;
+let failed = 0;
+
+async function hit(label, path, timeoutMs = 120_000) {
+    const url = `${BASE_URL}${path}`;
+    try {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), timeoutMs);
+        const res = await fetch(url, { signal: controller.signal });
+        clearTimeout(timer);
+        if (res.ok) {
+            const body = await res.text();
+            console.log(`  pass  ${label} (${body.length} bytes)`);
+            passed++;
+            return body;
+        }
+        console.log(`  FAIL  ${label} -> HTTP ${res.status}`);
+        failed++;
+        return null;
+    } catch (e) {
+        console.log(`  FAIL  ${label} -> ${e.message}`);
+        failed++;
+        return null;
+    }
+}
+
+async function main() {
+    console.log(`Target: ${BASE_URL}`);
+    console.log(`Mode:   ${QUICK ? "quick (DB-only)" : "full"}\n`);
+
+    // ── communities ────────────────────────────────────────────────────
+    let communities;
+    try {
+        const res = await fetch(`${BASE_URL}/v1/communities/all-communities`);
+        communities = await res.json();
+        console.log(
+            `  pass  all-communities (${communities.length} communities)`
+        );
+        passed++;
+    } catch (e) {
+        console.log(`  FAIL  all-communities -> ${e.message}`);
+        console.log("\nCannot fetch communities, aborting.");
+        process.exit(1);
+    }
+
+    const now = Date.now();
+    const oneYearAgo = now - 365 * 24 * 60 * 60 * 1000;
+    const currentYear = new Date().getUTCFullYear();
+    const years = QUICK
+        ? [currentYear]
+        : Array.from({ length: currentYear - START_YEAR + 1 }, (_, i) => START_YEAR + i);
+
+    // ── per-community endpoints ────────────────────────────────────────
+    for (const { cid, name } of communities) {
+        console.log(`\n[${name} / ${cid}]`);
+
+        // DB-only, fast
+        for (const y of years) {
+            await hit(`volume-report ${y}`, `/v1/accounting/volume-report?cid=${cid}&year=${y}`);
+            await hit(`transaction-activity ${y}`, `/v1/accounting/transaction-activity?cid=${cid}&year=${y}`);
+        }
+
+        // treasury log (DB-only, only for known treasury communities)
+        if (TREASURY_CIDS.has(cid)) {
+            await hit(
+                "community-treasury-log",
+                `/v1/accounting/community-treasury-log?cid=${cid}&start=${oneYearAgo}&end=${now}`
+            );
+        }
+
+        if (QUICK) continue;
+
+        // RPC-heavy endpoints (skip in --quick mode)
+        await hit("rewards-data", `/v1/accounting/rewards-data?cid=${cid}`, 600_000);
+        for (const y of years) {
+            await hit(
+                `money-velocity ${y}`,
+                `/v1/accounting/money-velocity-report?cid=${cid}&year=${y}`,
+                600_000
+            );
+        }
+        await hit("reputables-by-cindex", `/v1/accounting/reputables-by-cindex?cid=${cid}`, 600_000);
+        await hit("frequency-of-attendance", `/v1/accounting/frequency-of-attendance?cid=${cid}`, 600_000);
+
+        // all-accounts-data populates per-user cache (very slow)
+        for (const y of years) {
+            await hit(
+                `all-accounts-data ${y}`,
+                `/v1/accounting/all-accounts-data?cid=${cid}&year=${y}`,
+                600_000
+            );
+        }
+    }
+
+    // ── account-specific endpoints (sample account, Leu) ──────────────
+    console.log("\n[account-specific / sample]");
+    await hit(
+        "transaction-log",
+        `/v1/accounting/transaction-log?cid=u0qj944rhWE&start=${oneYearAgo}&end=${now}&account=${SAMPLE_ACCOUNT}`
+    );
+    await hit(
+        "native-transaction-log",
+        `/v1/accounting/native-transaction-log?start=${oneYearAgo}&end=${now}&account=${SAMPLE_ACCOUNT}`
+    );
+
+    if (!QUICK) {
+        await hit(
+            "account-overview",
+            `/v1/accounting/account-overview?cid=u0qj944rhWE&timestamp=${now}`,
+            300_000
+        );
+        await hit(
+            "sankey-report",
+            `/v1/accounting/sankey-report?cid=u0qj944rhWE&start=${oneYearAgo}&end=${now}&account=${SAMPLE_ACCOUNT}`,
+            300_000
+        );
+    }
+
+    // ── summary ────────────────────────────────────────────────────────
+    console.log(`\n${"=".repeat(50)}`);
+    console.log(`Results: ${passed} passed, ${failed} failed`);
+    console.log("=".repeat(50));
+    process.exit(failed > 0 ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
- CI runs on push/PR to main: npm ci, starts server, runs smoke tests (DB-only endpoints via --quick flag)
- scripts/warm-caches.js hits all endpoints with reasonable queries, usable in production to populate all caches (full mode) or in CI for quick smoke testing (--quick mode)
- Maps MONGODB_URL secret to DB_URL env var in workflow
- Uses Node 20 LTS